### PR TITLE
Fix go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module aead.dev/mtls
 
-go 1.22.0
+go 1.22


### PR DESCRIPTION
Set Go version to `1.22` to allow being included in projects that require the `1.22` version. Could you also release a v0.1.1 release, so we can use this in our other software?

PS: Feel free to downgrade to a lower version (lowest possible is `1.16`).