### PR TITLE
add support for boringcrypto FIPS build mode

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.22.7, 1.23.1]
+        go-version: [1.22.8, 1.23.2]
     steps:
     - name: Set up Go ${{ matrix.go-version }}
       uses: actions/setup-go@v5
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: [1.22.7, 1.23.1]
+        go-version: [1.22.8, 1.23.2]
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
     - name: Set up Go ${{ matrix.go-version }} on ${{ matrix.os }}
@@ -43,12 +43,27 @@ jobs:
     - name: Test on ${{ matrix.os }}
       run: |
          go test ./...
+  boringcrypto:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [1.22.8, 1.23.2]
+    steps:
+    - name: Set up Go ${{ matrix.go-version }}
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
+    - name: Test
+      run: |
+         CGO_ENABLED=1 GOEXPERIMENT=boringcrypto go test ./...
   vulncheck:
     name: Vulncheck ${{ matrix.go-version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.22.7, 1.23.1]
+        go-version: [1.22.8, 1.23.2]
     steps:
     - name: Set up Go ${{ matrix.go-version }}
       uses: actions/setup-go@v5

--- a/boring_test.go
+++ b/boring_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2024 Andreas Auernhammer. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+//go:build boringcrypto
+
+package mtls_test
+
+import (
+	"testing"
+
+	"aead.dev/mtls"
+)
+
+func TestBoringCrypto(t *testing.T) {
+	const Key = "k1:xZnpcYtPdVMNLBBRaUO5HPEoK_jVrcc3MWR8BshkjJw"
+
+	if _, err := mtls.ParsePrivateKey(Key); err == nil {
+		t.Fatal("Parsed Ed25519 private key in FIPS mode successfully")
+	}
+
+	if _, err := mtls.GenerateKeyEdDSA(nil); err == nil {
+		t.Fatal("Generated Ed25519 private key in FIPS mode successfully")
+	}
+
+	var k mtls.EdDSAPrivateKey
+	if err := k.UnmarshalText([]byte(Key)); err == nil {
+		t.Fatal("Unmarshaled Ed25519 private key in FIPS mode successfully")
+	}
+
+	if _, err := k.MarshalText(); err == nil {
+		t.Fatal("Marshaled Ed25519 private key in FIPS mode successfully")
+	}
+}

--- a/example_test.go
+++ b/example_test.go
@@ -85,7 +85,7 @@ func ExampleClient() {
 // certificate issued by a CA trusted by the client.
 func ExampleClient_PrivateKey() {
 	// The server's identity - required to verify mTLS handshakes at the client.
-	const Identity = "h1:dKNb3WhlZ1dxE6VSI1mH7FAd2EPTijEU37RHvkhuT7Y"
+	const Identity = "h1:5OEhsTTKZiK-IFE-Fi6W-VWwp_YLbxik0wxQBNc0_6s"
 
 	srvIdentity, err := mtls.ParseIdentity(Identity)
 	if err != nil {
@@ -95,7 +95,7 @@ func ExampleClient_PrivateKey() {
 	// The client's private key - used to authenticate to the server during mTLS handshakes.
 	// The server must know the identity of the client's private key to be able to verify
 	// the client.
-	const PrivateKey = "k1:rEvhGSEz3JBPamsG4x09DQ6qHOXElhGvXJeqRl4wD-c"
+	const PrivateKey = "k2:q-sFRxPrJNevr8cztwnMONKtC5eVC3an42AWijBGOtc"
 
 	clientKey, err := mtls.ParsePrivateKey(PrivateKey)
 	if err != nil {
@@ -159,7 +159,7 @@ func ExampleClient_PrivateKey() {
 //
 // The server does not authenticate clients.
 func ExampleServer() {
-	const PrivateKey = "k1:VUP2ZuJttWBTJpv3T8aeJR4jaemYYBgjqAri1uK78No"
+	const PrivateKey = "k2:IqYLb-5B3YvUR28WcJoGo3zhWa5GnrcJ9knLEWCHsRU"
 
 	priv, err := mtls.ParsePrivateKey(PrivateKey)
 	if err != nil {
@@ -201,7 +201,7 @@ func ExampleServer() {
 //
 // The server verifies clients using the VerifyPeerIdentity callback.
 func ExampleServer_VerifyPeerIdentity() {
-	const PrivateKey = "k1:VUP2ZuJttWBTJpv3T8aeJR4jaemYYBgjqAri1uK78No"
+	const PrivateKey = "k2:nJev7FTHw5Up-Hbev_iQ-ukYZtDbceXowrhUFcF9zd8"
 
 	priv, err := mtls.ParsePrivateKey(PrivateKey)
 	if err != nil {
@@ -209,7 +209,7 @@ func ExampleServer_VerifyPeerIdentity() {
 	}
 
 	// The client's identity - required to verify mTLS handshakes at the server.
-	const Identity = "h1:Ks-Q7OFe1W_ktXYdoBmHxLWKICLyGRj1P4wFQoZ2JKA"
+	const Identity = "h1:6mn2_7XHfySVJYH0JN5R0kYZjr8I7q4j34BogumV3tM"
 
 	clientIdentity, err := mtls.ParseIdentity(Identity)
 	if err != nil {
@@ -253,8 +253,8 @@ func ExampleServer_VerifyPeerIdentity() {
 func ExampleClientServer() {
 	// The client and server private key. Private keys should never be exposed!
 	const (
-		ServerPrivateKey = "k1:T5duXn2-loqNy4LJT9m-1u6bTi3-GvztEgeIkNYeypg" // Only known to the server
-		ClientPrivateKey = "k1:AqwjUvaWEE9O83quGOkiO_2D1x37Za9gE4L5UHdq0Ag" // Only known to the client
+		ServerPrivateKey = "k2:RsxEXi8ebLIWI8BI9MJHGBqKa1keq67Ds8hrgetZV1M" // Only known to the server
+		ClientPrivateKey = "k2:RtSJhCLcHMAcMlIynDayappxUNl0iSQtggHKNCUXrdQ" // Only known to the client
 	)
 
 	serverKey, err := mtls.ParsePrivateKey(ServerPrivateKey)
@@ -326,5 +326,5 @@ func ExampleClientServer() {
 		log.Fatal(err)
 	}
 	fmt.Println(buf.String())
-	// Output: Hello h1:FALvKoL5sB2mfvXrbheZ8tgKjIJZ60gN-VH9TcfK7Q0
+	// Output: Hello h1:OyfAzRVITGK2QUjHrYg0IC7y5hVjt93FZVucAgSuPeE
 }

--- a/internal/boring/boring.go
+++ b/internal/boring/boring.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2024 Andreas Auernhammer. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+//go:build boringcrypto
+
+package boring
+
+const FIPS = true

--- a/internal/boring/noboring.go
+++ b/internal/boring/noboring.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2024 Andreas Auernhammer. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+//go:build !boringcrypto
+
+package boring
+
+const FIPS = false


### PR DESCRIPTION
This commit adds the `internal/boringcrypto` package that exposes a single constant `FIPS=true` if the package is built with the build tag `boringcrypto` and `FIPS=false` otherwise.

The Go standard library (unofficially) supports a FIPS module via the `GOEXPERIMENT=boringcrypto` env. variable. If set, the Go compiler includes all source files with the build tag
```
go:build boringcrypto
```

In this "FIPS mode", we don't support Ed25519 since it's a cryptographic primitive that cannot be used as per the FIPS 140-2 standard. EDDSA over the curves P-256, P-384 and P-521 is still supported.

This needs to be re-visited once golang/go#69536 lands.